### PR TITLE
add client-side mutation call to clear votes

### DIFF
--- a/src/components/ClearVotes/ClearVotes.tsx
+++ b/src/components/ClearVotes/ClearVotes.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
-import { withStyles } from '@material-ui/core'
+import { withStyles } from '@material-ui/core';
+import { Mutation } from "react-apollo";
+import gql from "graphql-tag";
 
 interface Props {
   clearVotes: Function
@@ -17,8 +19,30 @@ const styled = withStyles(theme => ({
   }
 }))
 
+const CLEAR_VOTES_MUTATION = gql`
+  mutation clearVotes($sessionId: String!) {
+    clearVotes(sessionId: $sessionId) {
+      _id,
+      votes {
+        value
+      }
+    }
+  }
+`
+
 const ClearVotes = props => (
-  <button onClick={props.clearVotes}>Clear Votes</button>
+  <Mutation 
+    mutation={CLEAR_VOTES_MUTATION}
+  >
+    {(clearVotes: Function) => (
+      <button
+        onClick={e => clearVotes({ variables: { sessionId: '5d30eb3fedef94007010441a' }})}
+      >
+        {/* The above sessionId is hardcoded to test for now, must be made dynamic */}
+        Clear Votes
+      </button>
+    )}
+  </Mutation>
 )
 
 export default styled(ClearVotes)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const constants = {
-    local_session_id: "5d129f7829310c00b55a0dfe"
+    local_session_id: "5d30eb3fedef94007010441a"
 };


### PR DESCRIPTION
- `ClearVotes` component calls related mutation on button click
- `Card` component is automatically re-rendering due to Apollo's built-in state management (cache)
  - This requires the "mutated" data to be returned by the mutation call (`votes {}`)